### PR TITLE
Minor bugfixes

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -92,8 +92,8 @@ void doFrame1()
 
 	//setup lighting
 		vect3Df_s lightDir=vnormf(vect3Df(cos(lightAngle), -1.0f, sin(lightAngle)));
-		GPU_SetUniform(SHDR_GetUniformRegister(shader, "lightDirection", 0), (u32*)(float[]){0.0f, -lightDir.z, -lightDir.y, -lightDir.x}, 4);
-		GPU_SetUniform(SHDR_GetUniformRegister(shader, "lightAmbient", 0), (u32*)(float[]){0.7f, 0.4f, 0.4f, 0.4f}, 4);
+		GPU_SetUniform(SHDR_GetUniformRegister(shader, "lightDirection", 0), (u32*)(float[]){0.0f, -lightDir.z, -lightDir.y, -lightDir.x}, 1);
+		GPU_SetUniform(SHDR_GetUniformRegister(shader, "lightAmbient", 0), (u32*)(float[]){0.7f, 0.4f, 0.4f, 0.4f}, 1);
 
 	//draw world
 		gsMatrixMode(GS_MODELVIEW);

--- a/source/subscreen.c
+++ b/source/subscreen.c
@@ -36,6 +36,9 @@ void drawBlockSoft(gfxScreen_t screen, gfx3dSide_t side, u8* blockData, s16 x, s
 		const int bj=(j-y)>>f;
 		for(i=x; i<x+(BLOCK_SIZE<<f); i++)
 		{
+			if (i >= fbWidth) { continue; }
+			if (j >= fbHeight) { continue; }
+
 			const int bi=(i-x)>>f;
 			const int v=((i)+(j)*fbWidth)*3;
 			const int v2=((xOffset+bj)+(yOffset+BLOCK_SIZE-1-bi)*256)*4;


### PR DESCRIPTION
These are things I've observed while doing a hacky port to Linux (as a halfway point while porting to original Xbox):

- I assume the last parameter of `GPU_SetUniform` is a count of `vec4`, so having it at 4 (as done for matrices) actually reads 16 floats, but only 4 are provided.
- My `gfxGetFramebuffer` returns 320 and 240 in the last parameters (is this wrong?), and my watchpoint in the producer told me that memory got overwritten in the `drawBlockSoft` routine, so I added some hacky protection against out-of-bound writes. I'm not sure which draw in particular causes it (or why).

My port actually uses `uintptr_t` for `u32` because of some ugly hacks, and *if* we continue porting this to original Xbox you'll probably also receive a patch for that (and maybe similar patches / changes for your portal3DS repo in the distant future).

As I don't currently have access to a 3DS, Citra, or a toolchain, I'll just dump this here for you to review.

**These changes are untested in their intended environment.**